### PR TITLE
change flag + definition meta.curation meta.email

### DIFF
--- a/ucd-list.txt
+++ b/ucd-list.txt
@@ -133,9 +133,9 @@ P | meta.code.multip                  |  Multiplicity or binarity flag
 P | meta.code.qual                    |  Quality, precision, reliability flag or code                                  
 P | meta.code.status                  |  Status code (e.g.: status of a proposal/observation)                           
 P | meta.cryptic                      |  Unknown or impossible to understand quantity                                  
-P | meta.curation                     |  Identity of man/organization responsible for the data                         
+S | meta.curation                     |  Related to curation of the data                          
 Q | meta.dataset                      |  Dataset                                                                       
-Q | meta.email                        |  Curation/contact e-mail                                                        
+Q | meta.email                        |  Contact e-mail                                                        
 S | meta.file                         |  File                                                                          
 S | meta.fits                         |  FITS standard                                                                 
 P | meta.id                           |  Identifier, name or designation                                               


### PR DESCRIPTION
_meta.curation_ had P flag but SSA or Obscore implementations already use it in various combinations ( 22 occurrences in Gavo Registry).
Moving it to S for secondary word seems the least changes impacting running services. 
meta.id;meta.curation is the replacement for current usage of meta.curation  (12 occurrences in GAVO Registry ) to represent the name or id of curator/organisation 
_meta.email_ 's description, previously mentioning curation , is now defined more generally as 'Contact email'