### PR TITLE
This would add tests to ensure that the machine-readable lists are so…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,16 @@ VECTORFIGURES =
 # Additional files to distribute (e.g., CSS, schema files, examples...)
 AUX_FILES = localrefs.bib ucd-list.txt ucd-list-deprecated.txt
 
-include ivoatex/Makefile
+-include ivoatex/Makefile
+
+ivoatex/Makefile:
+	@echo "*** ivoatex submodule not found.  Initialising submodules."
+	@echo
+	git submodule update --init
+
+# dependency: a POSIX-compliant sort
+test:
+	@sort -t '|' -k 2 -f -c ucd-list-deprecated.txt
+	@sort -t '|' -k 2 -f -c ucd-list.txt
+
+


### PR DESCRIPTION
…rted.

I'm not actually saying they should be; right now, anyway, they are not.
ucd-list.txt would take a 200-line diff to become sorted.
ucd-list-deprecated.txt currently has "comments" in it and is sorted by
deprecation date.

This of course raises the question: Does it buy us anything to have these
files sorted?  Sure: it wouldn't be hard to do, but perhaps it's
actually preferable to have the Johnson bands in the conventional sequence
U, B, V, R, I, J, H, K?

I have also put in the auto-pulling of ivoatex from the current ivoatex
Makefile.  If this doesn't get merged because, that part should at least
go in.