### PR TITLE
Loumir make url for lists explicit

### DIFF
--- a/UCDlist.tex
+++ b/UCDlist.tex
@@ -803,8 +803,11 @@ for other details.
 
 \section{Associated Files}
 This document comes with two plain text files:
-\texttt{ucd-list.txt}\footnote{\auxiliaryurl{ucd-list.txt}} and 
-\texttt{ucd-list-deprecated.txt}\footnote{\auxiliaryurl{ucd-list-deprecated.txt}}. 
+%mir auxiliary function does not work \texttt{ucd-list.txt}\footnote{https://ivoa.net/documents/UCD1+/ucd-list.txt}} and 
+\texttt{ucd-list.txt}\footnote{https://ivoa.net/documents/UCD1+/20220706/ucd-list.txt} and 
+%mir auxiliary does not work \texttt{ucd-list-deprecated.txt}\footnote{\auxiliaryurl{ucd-list-deprecated.txt}}. 
+\texttt{ucd-list-deprecated.txt}\footnote{https://ivoa.net/documents/UCD1+/20220706/ucd-list-deprecated.txt}. 
+
 Their content is described below. 
 
 \subsection{UCD List file}

--- a/ucd-list-deprecated.txt
+++ b/ucd-list-deprecated.txt
@@ -1,3 +1,4 @@
+# UCDList version 1.5 
 # This file contains lists suggested replacements for UCD1+ which are deprecated
 # deprecated_term  replacement_term 
 em.IR.K.Brgamma em.line.Brgamma

--- a/ucd-list.txt
+++ b/ucd-list.txt
@@ -1,3 +1,4 @@
+# UCDList version 1.5 
 Q | arith                             |  Arithmetic quantities                                                         
 S | arith.diff                        |  Difference between two quantities described by the same UCD                   
 P | arith.factor                      |  Numerical factor                                                              

--- a/ucd-list.txt
+++ b/ucd-list.txt
@@ -1,4 +1,3 @@
-# UCDList version 1.5 
 Q | arith                             |  Arithmetic quantities                                                         
 S | arith.diff                        |  Difference between two quantities described by the same UCD                   
 P | arith.factor                      |  Numerical factor                                                              


### PR DESCRIPTION
added Version nb in files ucd-list.txt and ucd deprecated . 
useful when the file is copied . 

url to these files are written explicitly : auxiliaryurl does not seem to work .
