### PR TITLE
update-typos-MD-26July+linktopreviousdoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DOCNAME = UCDlist
 DOCVERSION = 1.5
 
 # Publication date, ISO format; update manually for "releases"
-DOCDATE = 2022-07-06
+DOCDATE = 2022-09-19
 
 # What is it you're writing: NOTE, WD, PR, REC, PEN, or EN
 DOCTYPE = PEN

--- a/UCDlist.tex
+++ b/UCDlist.tex
@@ -35,8 +35,8 @@
 
 \editor[mailto:baptiste.cecconi@obspm.fr]{Baptiste Cecconi, Mireille Louys}
 
-\previousversion[https://www.ivoa.net/documents/UCD1+/20210616/EN-UCDlist-1.4-20210616.pdf]{UCD1+ 
-controlled vocabulary-Updated List of terms Version 1.4}
+\previousversion[v1.4]{UCD1+ 
+controlled vocabulary-Updated List of terms Version 1.4 https://www.ivoa.net/documents/UCD1+/20210616/EN-UCDlist-1.4-20210616.pdf}
 
 \setcounter{secnumdepth}{5}  
 
@@ -760,7 +760,7 @@ They are exposed with a syntax tag given as a property of each UCD word
 and included in the list of UCD words. See Section \ref{sec:list} with the tags definitions on top.
 
 They correspond to real usage of the terms in science publications and are attached to the description 
-of catalogues’ column by experimented data scientists. UCD combination also reflects the catalogues 
+of catalogues column by experienced data scientists. UCD combination also reflects the catalogues 
 build-up strategy. Errors and statistics, for instance, are provided with measurement values; measures 
 and model comparison are evaluated with error fits, precision, etc. All the scientific knowledge helps 
 to define appropriate UCD words combination.
@@ -803,9 +803,7 @@ for other details.
 
 \section{Associated Files}
 This document comes with two plain text files:
-%mir auxiliary function does not work \texttt{ucd-list.txt}\footnote{https://ivoa.net/documents/UCD1+/ucd-list.txt}} and 
 \texttt{ucd-list.txt}\footnote{\url{https://ivoa.net/documents/UCD1+/20220706/ucd-list.txt}} and 
-%mir auxiliary does not work \texttt{ucd-list-deprecated.txt}\footnote{\auxiliaryurl{ucd-list-deprecated.txt}}. 
 \texttt{ucd-list-deprecated.txt}\footnote{\url{https://ivoa.net/documents/UCD1+/20220706/ucd-list-deprecated.txt}}. 
 
 Their content is described below. 
@@ -824,7 +822,7 @@ The \texttt{ucd-list-deprecated.txt} file is a plain text formatted table with t
 columns separated by a whitespace character. The first column contains the deprecated 
 UCD words, while the second contains word that should be used instead.
 
-Comment rows are starting with a \texttt{\#} (hash) character.
+Comment lines are starting with a \texttt{\#} (hash) character.
 
 \section{Changes from previous versions}
 \subsection{Changes from UCDList EN v1.4 following RFM}

--- a/UCDlist.tex
+++ b/UCDlist.tex
@@ -35,8 +35,13 @@
 
 \editor[mailto:baptiste.cecconi@obspm.fr]{Baptiste Cecconi, Mireille Louys}
 
-\previousversion[v1.4]{UCD1+ 
-controlled vocabulary-Updated List of terms Version 1.4 https://www.ivoa.net/documents/UCD1+/20210616/EN-UCDlist-1.4-20210616.pdf}
+\previousversion[https://www.ivoa.net/documents/UCD1+/20210616]{Endorsed
+Note 1.4}
+\previousversion[http://ivoa.net/documents/UCD1+/20180527/]{REC 1.3}
+\previousversion[http://ivoa.net/documents/cover/UCDlist-20070402.html]{REC
+1.23}
+\previousversion[https://ivoa.net/documents/cover/UCDlist-20051231.html]{REC
+1.1}
 
 \setcounter{secnumdepth}{5}  
 
@@ -44,13 +49,15 @@ controlled vocabulary-Updated List of terms Version 1.4 https://www.ivoa.net/doc
 \begin{abstract}
 This document describes the \emph{list of controlled terms}  building up the corpus of the Unified Content Descriptors, Version 1+ (UCD1+). 
 
-The document describing the UCD1+ principles can be found at the URL: \url{https://ivoa.net/documents/UCD1+/20180527/index.html}. 
+The document describing the UCD1+ principles can be found at the URL: \url{https://ivoa.net/documents/UCD1+/}. 
 It is an IVOA Recommendation. 
 The process to maintain and enrich the UCD list of terms is standardized in  \url{https://ivoa.net/documents/UCDlistMaintenance/}.
 It states that successive versions of the UCD1+ vocabulary are distributed in Endorsed Notes within the IVOA.
 
-The changes with respect to the version UCDList1.4 have been discussed in the request for modification (RFM) page on (\url{https://wiki.ivoa.net/twiki/bin/view/IVOA/UCDList_1-5_RFM}) within the IVOA Semantics WG and validated by the UCD science board.
-Each addition, amendment, etc.  is discussed now using VEP-UCD available from the RFM page  inspired from the set-up of Vocabulary Enhancement VEP2.0 specification (\url{https://ivoa.net/documents/Vocabularies/20210525/index.html}). 
+The changes with respect to the version UCDList1.4 have been discussed in the request for modification (RFM) page on \url{https://wiki.ivoa.net/twiki/bin/view/IVOA/UCDList_1-5_RFM} within the IVOA Semantics WG and validated by the UCD science board.
+Each addition, amendment, etc.  is discussed now using VEP-UCD available
+from the RFM page  inspired from the set-up described in
+Vocabularies in the VO 2 \citep{2021ivoa.spec.0525D}. 
 VEP-UCD files are referenced from the RFM page and available for further details.
 \end{abstract} 
 
@@ -760,7 +767,7 @@ They are exposed with a syntax tag given as a property of each UCD word
 and included in the list of UCD words. See Section \ref{sec:list} with the tags definitions on top.
 
 They correspond to real usage of the terms in science publications and are attached to the description 
-of catalogues column by experienced data scientists. UCD combination also reflects the catalogues 
+of catalogues' columns by experienced data scientists. UCD combination also reflects the catalogues 
 build-up strategy. Errors and statistics, for instance, are provided with measurement values; measures 
 and model comparison are evaluated with error fits, precision, etc. All the scientific knowledge helps 
 to define appropriate UCD words combination.
@@ -803,8 +810,8 @@ for other details.
 
 \section{Associated Files}
 This document comes with two plain text files:
-\texttt{ucd-list.txt}\footnote{\url{https://ivoa.net/documents/UCD1+/20220706/ucd-list.txt}} and 
-\texttt{ucd-list-deprecated.txt}\footnote{\url{https://ivoa.net/documents/UCD1+/20220706/ucd-list-deprecated.txt}}. 
+\texttt{ucd-list.txt}\footnote{\auxiliaryurl{ucd-list.txt}} and 
+\texttt{ucd-list-deprecated.txt}\footnote{\auxiliaryurl{ucd-list-deprecated.txt}}. 
 
 Their content is described below. 
 

--- a/ucd-list.txt
+++ b/ucd-list.txt
@@ -96,7 +96,7 @@ S | instr.filter                      |  Filter
 S | instr.fov                         |  Related to the field of view                                                                 
 S | instr.obsty                       |  Observatory, satellite, mission                                               
 Q | instr.obsty.seeing                |  Seeing                                                                        
-Q | instr.offset                      |  Offset angle respect to main direction of observation                         
+Q | instr.offset                      |  Offset angle with respect to main direction of observation                         
 Q | instr.order                       |  Spectral order in a spectrograph                                              
 Q | instr.param                       |  Various instrumental parameters                                               
 S | instr.pixel                       |  Pixel (default size: angular)                                                 


### PR DESCRIPTION
this update fixes some typos identified by Markus end of July.
I give up with the header tag in the list of terms. 
We must proceed for a next update of UCD terms for Ambiant parameters --> version 1.6

 