### PR TITLE
Add version tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,4 +41,4 @@ ivoatex/Makefile:
 	git submodule update --init
 
 test:
-	@echo "No tests defined yet"
+	@sh assert-version-tag.sh $(DOCTYPE) $(DOCNAME) $(DOCVERSION) $(DOCDATE)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DOCNAME = UCDlist
 DOCVERSION = 1.5
 
 # Publication date, ISO format; update manually for "releases"
-DOCDATE = 2022-07-06
+DOCDATE = 2022-07-15
 
 # What is it you're writing: NOTE, WD, PR, REC, PEN, or EN
 DOCTYPE = PEN

--- a/UCDlist.tex
+++ b/UCDlist.tex
@@ -11,17 +11,6 @@
 \usepackage{natbib} 
 % \usepackage{enumitem} 
 
-% Fixing specific BASEURL for this document
-\renewcommand{\ivoaBaseURL}{https://www.ivoa.net/documents/UCD1+}
-\renewcommand\currentDocURL % 
-	{\ivoaBaseURL/\ivoaDocdatecode}
-\renewcommand\currentDocRef % formatted reference to this document's landing page
-	{\href{\currentDocURL}{\currentDocURL}}
-\renewcommand\latestDocRef 
-	% formatted reference to a potential successor to the document's landing page
-	{\href{\ivoaBaseURL}{\ivoaBaseURL}}
-\renewcommand{\auxiliaryurl}[1]{\href{\currentDocURL/#1}{\currentDocURL/#1}}
-
 \title{UCD1+ controlled vocabulary - \emph{Updated List of Terms}}
 
 % having descriptions in a narrow column is painful -- the following
@@ -819,6 +808,10 @@ This document comes with two plain text files:
 \texttt{ucd-list-deprecated.txt}\footnote{\auxiliaryurl{ucd-list-deprecated.txt}}. 
 Their content is described below. 
 
+To simplify the distribution of these files with common software
+products, they are distributed under the Creative Commons CC0 public
+domain dedication.\footnote{\url{http://creativecommons.org/publicdomain/zero/1.0/}}
+
 \subsection{UCD List file}
 The \texttt{ucd-list.txt} file is a plain text formatted table with three columns.
 It is the source file of Table \ref{table:ucd-list}. It contains all UCD terms validated 
@@ -839,13 +832,15 @@ Comment rows are starting with a \texttt{\#} (hash) character.
 
 \subsection{Version tags in file}
 
-The first row of each of these files is a comment line containing the UCDList version 
+The first line of each of these files is a comment line containing the UCDList version 
 tag following this syntax: \texttt{\$DOCTYPE-\$DOCNAME-v\$DOCVERSION-\$DOCDATE}, such as, 
 e.g., \texttt{PEN-UCDlist-v1.5-20220706}.
 
 Solely the lists with version starting by \texttt{EN-UCDList} are valid reference for UCD 
 terms or deprecated terms. They correspond to the Endorsed Note at the final step of the 
-update cycle. Others are only work-in-progress and should not be referenced. 
+update cycle. Others are only work-in-progress and are only intended
+for review.   They should, in particular, not be distributed with
+external software products.
 
 \section{Changes from previous versions}
 \subsection{Changes from UCDList EN v1.4 following RFM}

--- a/UCDlist.tex
+++ b/UCDlist.tex
@@ -833,8 +833,11 @@ Comment rows are starting with a \texttt{\#} (hash) character.
 \subsection{Version tags in file}
 
 The first line of each of these files is a comment line containing the UCDList version 
-tag following this syntax: \texttt{\$DOCTYPE-\$DOCNAME-v\$DOCVERSION-\$DOCDATE}, such as, 
-e.g., \texttt{PEN-UCDlist-v1.5-20220706}.
+tag following the pattern
+\verb|#$DOCTYPE-$DOCNAME-v$DOCVERSION-$DOCDATE|, where the
+variable names are taken from ivoatex \citep{ivoatexDoc}.  For a
+pre-release list, such a first line might look like
+\verb|#PEN-UCDlist-v1.5-20220706|.
 
 Solely the lists with version starting by \texttt{EN-UCDList} are valid reference for UCD 
 terms or deprecated terms. They correspond to the Endorsed Note at the final step of the 

--- a/UCDlist.tex
+++ b/UCDlist.tex
@@ -10,6 +10,18 @@
 \usepackage{array}
 \usepackage{natbib} 
 % \usepackage{enumitem} 
+
+% Fixing specific BASEURL for this document
+\renewcommand{\ivoaBaseURL}{https://www.ivoa.net/documents/UCD1+}
+\renewcommand\currentDocURL % 
+	{\ivoaBaseURL/\ivoaDocdatecode}
+\renewcommand\currentDocRef % formatted reference to this document's landing page
+	{\href{\currentDocURL}{\currentDocURL}}
+\renewcommand\latestDocRef 
+	% formatted reference to a potential successor to the document's landing page
+	{\href{\ivoaBaseURL}{\ivoaBaseURL}}
+\renewcommand{\auxiliaryurl}[1]{\href{\currentDocURL/#1}{\currentDocURL/#1}}
+
 \title{UCD1+ controlled vocabulary - \emph{Updated List of Terms}}
 
 % having descriptions in a narrow column is painful -- the following
@@ -760,7 +772,7 @@ They are exposed with a syntax tag given as a property of each UCD word
 and included in the list of UCD words. See Section \ref{sec:list} with the tags definitions on top.
 
 They correspond to real usage of the terms in science publications and are attached to the description 
-of catalogues’ column by experimented data scientists. UCD combination also reflects the catalogues 
+of catalogues' column by experimented data scientists. UCD combination also reflects the catalogues 
 build-up strategy. Errors and statistics, for instance, are provided with measurement values; measures 
 and model comparison are evaluated with error fits, precision, etc. All the scientific knowledge helps 
 to define appropriate UCD words combination.
@@ -803,17 +815,14 @@ for other details.
 
 \section{Associated Files}
 This document comes with two plain text files:
-%mir auxiliary function does not work \texttt{ucd-list.txt}\footnote{https://ivoa.net/documents/UCD1+/ucd-list.txt}} and 
-\texttt{ucd-list.txt}\footnote{\url{https://ivoa.net/documents/UCD1+/20220706/ucd-list.txt}} and 
-%mir auxiliary does not work \texttt{ucd-list-deprecated.txt}\footnote{\auxiliaryurl{ucd-list-deprecated.txt}}. 
-\texttt{ucd-list-deprecated.txt}\footnote{\url{https://ivoa.net/documents/UCD1+/20220706/ucd-list-deprecated.txt}}. 
-
+\texttt{ucd-list.txt}\footnote{\auxiliaryurl{ucd-list.txt}} and 
+\texttt{ucd-list-deprecated.txt}\footnote{\auxiliaryurl{ucd-list-deprecated.txt}}. 
 Their content is described below. 
 
 \subsection{UCD List file}
-The \texttt{ucd-list.txt} file is a plain text formatted table with
-three columns.
-It is the source file of Table \ref{table:ucd-list}. It contains all UCD terms validated for this version of this IVOA Note.
+The \texttt{ucd-list.txt} file is a plain text formatted table with three columns.
+It is the source file of Table \ref{table:ucd-list}. It contains all UCD terms validated 
+for this version of this IVOA Note.
 
 The columns are separated by \texttt{|} (pipe) characters. From left to right, the 
 columns contain, respectively, the \emph{positional syntax code}, the \emph{UCD word}, and its
@@ -824,13 +833,19 @@ The \texttt{ucd-list-deprecated.txt} file is a plain text formatted table with t
 columns separated by a whitespace character. The first column contains the deprecated 
 UCD words, while the second contains the UCD term that should be used instead.
 
-NB: Comment rows are starting with a \texttt{\#} (hash) character. \\
-The first row of each of these files contains a comment line with the version tag following this syntax:\\
-\verbatim{$DOCTYPE-$DOCNAME-v$DOCVERSION-$DOCDATE}
-such as PEN-UCDList-v1.5-20220706 for instance .
-Caveat : Only the lists with version starting by EN-UCDList-... are valid reference for UCD terms or deprecated terms. 
-They correspond to the Endorsed Note at the final step of the update cycle. 
-Others are only work-in-progress and should not be referenced. 
+\subsection{Comments in file}
+
+Comment rows are starting with a \texttt{\#} (hash) character.
+
+\subsection{Version tags in file}
+
+The first row of each of these files is a comment line containing the UCDList version 
+tag following this syntax: \texttt{\$DOCTYPE-\$DOCNAME-v\$DOCVERSION-\$DOCDATE}, such as, 
+e.g., \texttt{PEN-UCDlist-v1.5-20220706}.
+
+Solely the lists with version starting by \texttt{EN-UCDList} are valid reference for UCD 
+terms or deprecated terms. They correspond to the Endorsed Note at the final step of the 
+update cycle. Others are only work-in-progress and should not be referenced. 
 
 \section{Changes from previous versions}
 \subsection{Changes from UCDList EN v1.4 following RFM}

--- a/UCDlist.tex
+++ b/UCDlist.tex
@@ -804,9 +804,9 @@ for other details.
 \section{Associated Files}
 This document comes with two plain text files:
 %mir auxiliary function does not work \texttt{ucd-list.txt}\footnote{https://ivoa.net/documents/UCD1+/ucd-list.txt}} and 
-\texttt{ucd-list.txt}\footnote{https://ivoa.net/documents/UCD1+/20220706/ucd-list.txt} and 
+\texttt{ucd-list.txt}\footnote{\url{https://ivoa.net/documents/UCD1+/20220706/ucd-list.txt}} and 
 %mir auxiliary does not work \texttt{ucd-list-deprecated.txt}\footnote{\auxiliaryurl{ucd-list-deprecated.txt}}. 
-\texttt{ucd-list-deprecated.txt}\footnote{https://ivoa.net/documents/UCD1+/20220706/ucd-list-deprecated.txt}. 
+\texttt{ucd-list-deprecated.txt}\footnote{\url{https://ivoa.net/documents/UCD1+/20220706/ucd-list-deprecated.txt}}. 
 
 Their content is described below. 
 

--- a/assert-version-tag.sh
+++ b/assert-version-tag.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# make sure the version tags on the UCD lists match what we define in
+# the Makefile
+
+DOCTYPE=$1
+DOCNAME=$2
+DOCVERSION=$3
+DOCDATE=$4
+
+function check_version_tag() {
+	found_tag=`head -1 $1`
+	expected_tag="#$DOCTYPE-$DOCNAME-v$DOCVERSION-$DOCDATE"
+
+	if [ "$found_tag" != "$expected_tag" ]; then
+		echo "Bad version tag on $1: $found_tag"
+		echo "(Expected: $expected_tag)"
+		exit 1
+	fi
+}
+
+check_version_tag ucd-list.txt
+check_version_tag ucd-list-deprecated.txt
+exit 0

--- a/convert_ucd_list_to_tex.py
+++ b/convert_ucd_list_to_tex.py
@@ -11,7 +11,8 @@ def ucd_to_tex(file):
     with open(file, 'r') as f:
         lines = f.readlines()
         for cur_line in lines:
-            convert_line(cur_line)
+            if not cur_line.startswith("#"):
+                 convert_line(cur_line)
 
 if __name__ == '__main__':
     argv = sys.argv[1:]

--- a/ucd-list-deprecated.txt
+++ b/ucd-list-deprecated.txt
@@ -1,4 +1,4 @@
-# UCDList version 1.5 
+# PEN-UCDlist-v1.5-20220715
 # This file contains lists suggested replacements for UCD1+ which are deprecated
 # deprecated_term  replacement_term 
 em.IR.K.Brgamma em.line.Brgamma

--- a/ucd-list-deprecated.txt
+++ b/ucd-list-deprecated.txt
@@ -1,4 +1,4 @@
-# PEN-UCDlist-v1.5-20220715
+#PEN-UCDlist-v1.5-2022-07-15
 # This file contains lists suggested replacements for UCD1+ which are deprecated
 # deprecated_term  replacement_term 
 em.IR.K.Brgamma em.line.Brgamma

--- a/ucd-list-deprecated.txt
+++ b/ucd-list-deprecated.txt
@@ -214,3 +214,4 @@ em.UV.FUV em.UV.100-200nm
 meta.ref.ivorn meta.ref.ivoid
 pos.bodyrc.long pos.bodyrc.lon
 pos.eop.nutation pos.nutation
+# This file distributed under CC-0 by the IVOA.

--- a/ucd-list.txt
+++ b/ucd-list.txt
@@ -1,4 +1,4 @@
-# PEN-UCDlist-v1.5-20220715
+#PEN-UCDlist-v1.5-2022-07-15
 Q | arith                             |  Arithmetic quantities                                                         
 S | arith.diff                        |  Difference between two quantities described by the same UCD                   
 P | arith.factor                      |  Numerical factor                                                              

--- a/ucd-list.txt
+++ b/ucd-list.txt
@@ -553,3 +553,4 @@ Q | time.release                      |  The time/date data is available to the 
 Q | time.resolution                   |  Time resolution                                                               
 Q | time.scale                        |  Timescale
 Q | time.start                        |  Start time/date of generic event
+# This file distributed under CC-0 by the IVOA

--- a/ucd-list.txt
+++ b/ucd-list.txt
@@ -1,3 +1,4 @@
+# PEN-UCDlist-v1.5-20220715
 Q | arith                             |  Arithmetic quantities                                                         
 S | arith.diff                        |  Difference between two quantities described by the same UCD                   
 P | arith.factor                      |  Numerical factor                                                              


### PR DESCRIPTION
This PR proposes to add structured comments at the beginning of the lists of UCDs and deprecated UCDs.  It collects commits from PR #79, which in turn took up PRs #77 and #75.

While I (Markus) still consider this will cause a significant amount of work for a very unclear benefit, I won't stand in the way of merging this now that there's a test making sure the tags at least match the rules.